### PR TITLE
Fixed extract logic

### DIFF
--- a/InstallModuleFromGitHub.psm1
+++ b/InstallModuleFromGitHub.psm1
@@ -31,21 +31,27 @@ function Install-ModuleFromGitHub {
                 $OutFile = Join-Path -Path $tmpDir -ChildPath "$($targetModuleName).zip"
                 Write-Debug "OutFile: $OutFile"
 
-                Invoke-RestMethod $url -OutFile $OutFile
-                if ($IsWindows) {
+
+                if ($IsLinux -or $IsOSX) {
+                  Invoke-RestMethod $url -OutFile $OutFile
+                }
+
+                else {
+                  Invoke-RestMethod $url -OutFile $OutFile
                   Unblock-File $OutFile
                 }
+
                 Expand-Archive -Path $OutFile -DestinationPath $tmpDir -Force
 
                 $unzippedArchive = "$($targetModuleName)-$($Branch)"
                 Write-Debug "targetModule: $targetModule"
 
-                if ($IsWindows) {
-                  $dest = "C:\Program Files\WindowsPowerShell\Modules"
+                if ($IsLinux -or $IsOSX) {
+                  $dest = Join-Path -Path $HOME -ChildPath ".local/share/powershell/Modules"
                 }
 
                 else {
-                  $dest = Join-Path -Path $HOME -ChildPath ".local/share/powershell/Modules"
+                  $dest = "C:\Program Files\WindowsPowerShell\Modules"
                 }
 
                 if($DestinationPath) {


### PR DESCRIPTION
Somewhere between the office and home, I screwed up the original PR. It was failing on expanding the archive and subsequently copying it to the proper module directory. I have now fixed that.  I did just test on OSX and Ubuntu 16.04, and Windows 10.

However, one thing that I did not think through before I started this, is having the cross-platform support now makes this module require the Alpha release of Powershell 6.0.  The boolean environment variables ($IsLinux, $IsWindows, $IsOSX) are only present in the 6.0 Alpha.  

Feel free to rollback if so desired. I have this forked and can use the cross platform functionality that way.