### PR TITLE
Updated some MacOS path issues and added CurrentUser Scope param

### DIFF
--- a/InstallModuleFromGitHub.psm1
+++ b/InstallModuleFromGitHub.psm1
@@ -7,7 +7,8 @@ function Install-ModuleFromGitHub {
         $ProjectUri,
         $DestinationPath,
         $SSOToken,
-        $moduleName
+        $moduleName,
+        $Scope
     )
 
     Process {
@@ -41,11 +42,11 @@ function Install-ModuleFromGitHub {
                 if ($SSOToken) {$headers = @{"Authorization" = "token $SSOToken" }}
 
                 #enable TLS1.2 encryption
-                if (-not ($IsLinux -or $IsOSX)) {
+                if (-not ([System.Environment]::OSVersion.Platform -eq "Unix")) {
                     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
                 }
                 Invoke-RestMethod $url -OutFile $OutFile -Headers $headers
-                if (-not ($IsLinux -or $IsOSX)) {
+                if (-not ([System.Environment]::OSVersion.Platform -eq "Unix")) {
                   Unblock-File $OutFile
                 }
 
@@ -57,29 +58,42 @@ function Install-ModuleFromGitHub {
                 $unzippedArchive = get-childItem "$tmpDir"
                 Write-Debug "targetModule: $targetModule"
 
-                if ($IsLinux -or $IsOSX) {
+                if ([System.Environment]::OSVersion.Platform -eq "Unix") {
                   $dest = Join-Path -Path $HOME -ChildPath ".local/share/powershell/Modules"
                 }
 
                 else {
-                  $dest = "C:\Program Files\WindowsPowerShell\Modules"
+                    if ($Scope = "CurrentUser") {
+                        $scopedPath = $HOME
+                        $scopedChildPath = "\Documents\WindowsPowerShell\Modules"
+                    } else {
+                        $scopedPath = $env:ProgramFiles
+                        $scopedChildPath = "C:\Program Files\WindowsPowerShell\Modules"
+                    }
+                  $dest = Join-Path -Path $scopedPath -ChildPath $scopedChildPath
                 }
 
                 if($DestinationPath) {
                     $dest = $DestinationPath
                 }
                 $dest = Join-Path -Path $dest -ChildPath $targetModuleName
-
-                $psd1 = Get-ChildItem (Join-Path -Path $tmpDir -ChildPath $unzippedArchive) -Include *.psd1 -Recurse
-
+                if ([System.Environment]::OSVersion.Platform -eq "Unix") {
+                    $psd1 = Get-ChildItem (Join-Path -Path $unzippedArchive -ChildPath *) -Include *.psd1 -Recurse
+                } else {
+                    $psd1 = Get-ChildItem (Join-Path -Path $tmpDir -ChildPath $unzippedArchive) -Include *.psd1 -Recurse
+                }
+                
                 if($psd1) {
                     $ModuleVersion=(Get-Content -Raw $psd1.FullName | Invoke-Expression).ModuleVersion
                     $dest = Join-Path -Path $dest -ChildPath $ModuleVersion
                     $null = New-Item -ItemType directory -Path $dest -Force
                 }
 
-                $null = Copy-Item "$(Join-Path -Path $tmpDir -ChildPath $unzippedArchive\*)" $dest -Force -Recurse
-
+                if ([System.Environment]::OSVersion.Platform -eq "Unix") {
+                    $null = Copy-Item "$(Join-Path -Path $unzippedArchive -ChildPath *)" $dest -Force -Recurse
+                } else {
+                    $null = Copy-Item "$(Join-Path -Path $tmpDir -ChildPath $unzippedArchive\*)" $dest -Force -Recurse
+                }
         }
     }
 }

--- a/InstallModuleFromGitHub.psm1
+++ b/InstallModuleFromGitHub.psm1
@@ -42,7 +42,7 @@ function Install-ModuleFromGitHub {
                 if ($SSOToken) {$headers = @{"Authorization" = "token $SSOToken" }}
 
                 #enable TLS1.2 encryption
-                if (-not ([System.Environment]::OSVersion.Platform -eq "Unix")) {
+                if (-not ($IsLinux -or $IsMacOS)) {
                     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
                 }
                 Invoke-RestMethod $url -OutFile $OutFile -Headers $headers
@@ -68,7 +68,7 @@ function Install-ModuleFromGitHub {
                         $scopedChildPath = "\Documents\WindowsPowerShell\Modules"
                     } else {
                         $scopedPath = $env:ProgramFiles
-                        $scopedChildPath = "C:\Program Files\WindowsPowerShell\Modules"
+                        $scopedChildPath = "\WindowsPowerShell\Modules"
                     }
                   $dest = Join-Path -Path $scopedPath -ChildPath $scopedChildPath
                 }
@@ -83,6 +83,7 @@ function Install-ModuleFromGitHub {
                     $psd1 = Get-ChildItem (Join-Path -Path $tmpDir -ChildPath $unzippedArchive) -Include *.psd1 -Recurse
                 }
                 
+
                 if($psd1) {
                     $ModuleVersion=(Get-Content -Raw $psd1.FullName | Invoke-Expression).ModuleVersion
                     $dest = Join-Path -Path $dest -ChildPath $ModuleVersion


### PR DESCRIPTION
I was having a few issues using this on macos and added some fixes for the $psd1 path. It's maybe not the most elegant, but it's working well on my mac and my windows pc. Additionally, since I dont have permissions to install modules system wide, I added a CurrentUser scope optional parameter. 

Some Changes I made...
- $IsOSX isn't working as expected. Perhaps it should be $IsMacOS? In any case, I opted for [System.Environment]::OSVersion.Platform -eq "Unix" as a catch all for non-windows systems
- I replaced the hard coded Module paths assigned to $dest with environment variables instead. 
- if logic for Windows vs Non-Windows machines in assigning $psd1 and in the final Copy-Item statement. 

If you prefer this PR be broken down into smaller chunks, I can do that too. Just let me know. Thanks!