### PR TITLE
Corrected SCOPE paths for PS 7.x (Windows and Mac)

### DIFF
--- a/InstallModuleFromGitHub.psm1
+++ b/InstallModuleFromGitHub.psm1
@@ -59,16 +59,20 @@ function Install-ModuleFromGitHub {
                 Write-Debug "targetModule: $targetModule"
 
                 if ([System.Environment]::OSVersion.Platform -eq "Unix") {
-                  $dest = Join-Path -Path $HOME -ChildPath ".local/share/powershell/Modules"
+                    if ($Scope = "CurrentUser") {
+                        $dest = Join-Path -Path $HOME -ChildPath ".local/share/powershell/Modules"
+                    } else {
+                        $dest = "/usr/local/share/powershell/Modules"
+                    }
                 }
 
                 else {
                     if ($Scope = "CurrentUser") {
                         $scopedPath = $HOME
-                        $scopedChildPath = "\Documents\WindowsPowerShell\Modules"
+                        $scopedChildPath = "\Documents\PowerShell\Modules"
                     } else {
                         $scopedPath = $env:ProgramFiles
-                        $scopedChildPath = "\WindowsPowerShell\Modules"
+                        $scopedChildPath = "\PowerShell\Modules"
                     }
                   $dest = Join-Path -Path $scopedPath -ChildPath $scopedChildPath
                 }
@@ -81,8 +85,7 @@ function Install-ModuleFromGitHub {
                     $psd1 = Get-ChildItem (Join-Path -Path $unzippedArchive -ChildPath *) -Include *.psd1 -Recurse
                 } else {
                     $psd1 = Get-ChildItem (Join-Path -Path $tmpDir -ChildPath $unzippedArchive) -Include *.psd1 -Recurse
-                }
-                
+                } 
 
                 if($psd1) {
                     $ModuleVersion=(Get-Content -Raw $psd1.FullName | Invoke-Expression).ModuleVersion


### PR DESCRIPTION
Per last PR comments, I set the Scoped paths for module installation to work for PS 7.x on Windows and MacOS. I'll keep a separate fork for PS 5.1 for myself.

Changes (for PS 7.x)
- Windows AllUsers scope (default): `$env:ProgramFiles\PowerShell\Modules`
- Windows CurrentUser scope: `$HOME\Documents\PowerShell\Modules`
- Mac AllUsers scope (default): `/usr/local/share/powershell/Modules`
- Mac CurrentUser scope: `$HOME/.local/share/powershell/Modules`
