### PR TITLE
fix unzippedArchive path when searching for psd1 file

### DIFF
--- a/InstallModuleFromGitHub.psm1
+++ b/InstallModuleFromGitHub.psm1
@@ -84,19 +84,24 @@ function Install-ModuleFromGitHub {
                 if ([System.Environment]::OSVersion.Platform -eq "Unix") {
                     $psd1 = Get-ChildItem (Join-Path -Path $unzippedArchive -ChildPath *) -Include *.psd1 -Recurse
                 } else {
-                    $psd1 = Get-ChildItem (Join-Path -Path $tmpDir -ChildPath $unzippedArchive) -Include *.psd1 -Recurse
+                    $psd1 = Get-ChildItem (Join-Path -Path $tmpDir -ChildPath $unzippedArchive.Name) -Include *.psd1 -Recurse
                 } 
+
+                $sourcePath = $unzippedArchive.FullName
 
                 if($psd1) {
                     $ModuleVersion=(Get-Content -Raw $psd1.FullName | Invoke-Expression).ModuleVersion
                     $dest = Join-Path -Path $dest -ChildPath $ModuleVersion
                     $null = New-Item -ItemType directory -Path $dest -Force
+                    $sourcePath = $psd1.DirectoryName
                 }
+
+
 
                 if ([System.Environment]::OSVersion.Platform -eq "Unix") {
                     $null = Copy-Item "$(Join-Path -Path $unzippedArchive -ChildPath *)" $dest -Force -Recurse
                 } else {
-                    $null = Copy-Item "$(Join-Path -Path $tmpDir -ChildPath $unzippedArchive\*)" $dest -Force -Recurse
+                    $null = Copy-Item "$sourcePath\*" $dest -Force -Recurse
                 }
         }
     }


### PR DESCRIPTION
Two changes:
* on non-unix platforms, fixed the psd1 file search
  * join-path on line 87 was joining two full paths, which is not a
    valid result.
  * I'm curious if this code path ever worked before.  Is there something different about the test environment?  I'm running windows 10, pwsh v7.
* allow the module to be in a repo subdirectory
  * This would only be a breaking change if there could be module
    dependencies in a parent directory above the module root, which I
    don't think is possible.  It also wouldn't support nested modules,
    but I don't think those are supported by InstallModuleFromGitHub anyways.